### PR TITLE
feat: add clear input button

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -3,7 +3,8 @@
     "allow": [
       "Bash(rm:*)",
       "Bash(npm start)",
-      "Bash(npx docusaurus start:*)"
+      "Bash(npx docusaurus start:*)",
+      "Bash(git checkout:*)"
     ]
   }
 }

--- a/src/App.css
+++ b/src/App.css
@@ -25,9 +25,15 @@
   margin-bottom: 1.5rem;
 }
 
-.todo-input {
+.input-container {
   flex: 1;
+  position: relative;
+}
+
+.todo-input {
+  width: 100%;
   padding: 0.75rem;
+  padding-right: 3rem;
   border: 2px solid #ddd;
   border-radius: 4px;
   font-size: 1rem;
@@ -36,6 +42,31 @@
 .todo-input:focus {
   outline: none;
   border-color: #646cff;
+}
+
+.clear-input-button {
+  position: absolute;
+  right: 0.5rem;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  font-size: 1.2rem;
+  color: #999;
+  cursor: pointer;
+  padding: 0.25rem;
+  border-radius: 50%;
+  width: 2rem;
+  height: 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.2s;
+}
+
+.clear-input-button:hover {
+  background-color: #f0f0f0;
+  color: #666;
 }
 
 .add-button {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -88,13 +88,25 @@ function App() {
         <h1>Todo List</h1>
         
         <form onSubmit={handleSubmit} className="todo-form">
-          <input
-            type="text"
-            value={inputValue}
-            onChange={(e) => setInputValue(e.target.value)}
-            placeholder="Add a new todo..."
-            className="todo-input"
-          />
+          <div className="input-container">
+            <input
+              type="text"
+              value={inputValue}
+              onChange={(e) => setInputValue(e.target.value)}
+              placeholder="Add a new todo..."
+              className="todo-input"
+            />
+            {inputValue.length > 0 && (
+              <button
+                type="button"
+                onClick={() => setInputValue('')}
+                className="clear-input-button"
+                title="Clear input"
+              >
+                ✕
+              </button>
+            )}
+          </div>
           <button type="submit" className="add-button">Add</button>
         </form>
 


### PR DESCRIPTION
## Summary
- Added clear button (✕) to todo input field
- Button appears only when input contains text
- One-click clearing of input field for better UX

## Changes
- Add conditional clear button with ✕ symbol
- Position button on right side of input field
- Add hover effects and circular design
- Update input padding to accommodate button
- Responsive design that works on all devices

## Features
- ✕ **Clear button** appears when typing
- 🎯 **Click to clear** input instantly
- 🎨 **Smooth hover** effects
- 📱 **Touch-friendly** on mobile

## Test Plan
- [x] Button appears when typing in input
- [x] Button disappears when input is empty
- [x] Clicking button clears input completely
- [x] Hover effects work correctly
- [x] Responsive design on mobile

This PR should trigger the documentation pipeline again to test the fixes.

🤖 Generated with [Claude Code](https://claude.ai/code)