### PR TITLE
feat: add creation date display to todo items

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -4,7 +4,8 @@
       "Bash(rm:*)",
       "Bash(npm start)",
       "Bash(npx docusaurus start:*)",
-      "Bash(git add:*)"
+      "Bash(git add:*)",
+      "Bash(gh run view:*)"
     ]
   }
 }

--- a/src/App.css
+++ b/src/App.css
@@ -117,14 +117,28 @@
   height: 1.25rem;
 }
 
-.todo-text {
+.todo-text-container {
   flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.todo-text {
   text-align: left;
+  font-size: 1rem;
+  line-height: 1.4;
 }
 
 .todo-text.completed {
   text-decoration: line-through;
   color: #888;
+}
+
+.todo-date {
+  font-size: 0.75rem;
+  color: #999;
+  text-align: left;
 }
 
 .todo-actions {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -126,9 +126,14 @@ function App() {
                   onChange={() => toggleTodo(todo.id)}
                   className="todo-checkbox"
                 />
-                <span className={todo.completed ? 'todo-text completed' : 'todo-text'}>
-                  {todo.text}
-                </span>
+                <div className="todo-text-container">
+                  <span className={todo.completed ? 'todo-text completed' : 'todo-text'}>
+                    {todo.text}
+                  </span>
+                  <span className="todo-date">
+                    {new Date(todo.createdAt).toLocaleDateString()}
+                  </span>
+                </div>
               </div>
               <div className="todo-actions">
                 <button

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -131,6 +131,7 @@ function App() {
                     {todo.text}
                   </span>
                   <span className="todo-date">
+                    {/* Display creation date in user's locale */}
                     {new Date(todo.createdAt).toLocaleDateString()}
                   </span>
                 </div>


### PR DESCRIPTION
## Summary
- Display creation date below each todo item text
- Shows when each task was created for better organization
- Uses localized date format for user's locale

## Changes
- Add `todo-text-container` wrapper for text and date
- Display creation date with small gray styling
- Update CSS layout to accommodate date display
- Maintain responsive design for mobile devices

## Features
- 📅 **Creation date** displayed below todo text
- 🌍 **Localized format** based on user's locale
- 📱 **Mobile friendly** responsive design
- 🎨 **Subtle styling** that doesn't interfere with main content

## Test Plan
- [x] Date displays correctly for new todos
- [x] Date formatting matches user locale
- [x] Layout works on mobile devices
- [x] Styling integrates well with existing design
- [x] Performance remains smooth with date calculations

This PR will test the complete documentation pipeline with the `base: main` fix we just implemented!

🤖 Generated with [Claude Code](https://claude.ai/code)