### PR TITLE
feat: add todo count badge to page title

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,4 @@ export default tseslint.config([
   },
 ])
 ```
+# Test pipeline with 15 max-turns

--- a/src/App.css
+++ b/src/App.css
@@ -491,3 +491,19 @@
   width: 1rem;
   text-align: center;
 }
+
+/* Todo count badge */
+.todo-count-badge {
+  background: #646cff;
+  color: white;
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.25rem 0.5rem;
+  border-radius: 12px;
+  margin-left: 0.5rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.5rem;
+  height: 1.5rem;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -87,7 +87,12 @@ function App() {
     <div className="app-wrapper">
       <Navbar theme={theme} toggleTheme={toggleTheme} />
       <div className="app">
-        <h1>Todo List</h1>
+        <h1>
+          Todo List 
+          {stats.total > 0 && (
+            <span className="todo-count-badge">{stats.total}</span>
+          )}
+        </h1>
         
         <form onSubmit={handleSubmit} className="todo-form">
           <div className="input-container">


### PR DESCRIPTION
## Summary
Added a visual badge next to the page title that displays the total count of todos, providing immediate visual feedback about task volume.

## 🎯 Feature Details
- **Visual Badge**: Clean, modern badge showing total todo count
- **Conditional Display**: Only appears when todos exist (count > 0)
- **Real-time Updates**: Badge updates automatically as todos are added/removed
- **Consistent Styling**: Matches app's blue color scheme (#646cff)

## 📱 User Experience
- **Quick Reference**: Users can instantly see todo count without scrolling
- **Visual Hierarchy**: Badge is positioned prominently but doesn't dominate the title
- **Clean Design**: Rounded badge with proper spacing and typography
- **Responsive**: Maintains proper layout on all screen sizes

## 💻 Technical Implementation
- **Conditional Rendering**: `{stats.total > 0 && (...)}`
- **CSS Styling**: Custom `.todo-count-badge` class with flexbox alignment
- **State Integration**: Uses existing `stats.total` from `useTodos` hook
- **Performance**: Minimal overhead with simple conditional rendering

## 🧪 Test Scenarios
This simple feature tests our enhanced documentation pipeline:
- ✅ UI component addition (badge display logic)
- ✅ CSS styling updates (new badge class)
- ✅ State integration (using existing stats)
- ✅ Should generate docs for badge component functionality

**Expected Documentation**: The Docusaurus pipeline should now create documentation explaining the todo count badge feature with 15 max-turns available.

🤖 Generated with [Claude Code](https://claude.ai/code)